### PR TITLE
Add WH IBC info

### DIFF
--- a/ibc_info.json
+++ b/ibc_info.json
@@ -19,7 +19,7 @@
       "dst_channel": "channel-3",
       "src_channel": "channel-15",
       "port_id": "wasm.sei1nna9mzp274djrgzhzkac2gvm3j27l402s4xzr08chq57pjsupqnqaj0d5s",
-      "client_id": " 07-tendermint-12"
+      "client_id": "07-tendermint-55"
     }
   ]
 }

--- a/ibc_info.json
+++ b/ibc_info.json
@@ -13,6 +13,13 @@
       "src_channel": "channel-44",
       "port_id": "transfer",
       "client_id": "07-tendermint-80"
+    },
+    {
+      "counterparty_chain_name": "wormchain-testnet-0",
+      "dst_channel": "channel-3",
+      "src_channel": "channel-15",
+      "port_id": "wasm.sei1nna9mzp274djrgzhzkac2gvm3j27l402s4xzr08chq57pjsupqnqaj0d5s",
+      "client_id": " 07-tendermint-12"
     }
   ]
 }


### PR DESCRIPTION
- Adds WH IBC info for channel between SEI <> Wormchain 
- Bridging out via WH uses IBC channel from sei <> Wormchain testnet
Verified IBC info:
```Atlantic-2
client_id: 07-tendermint-55

channel_id: channel-15
  connection_hops:
  - connection-29
  counterparty:
    channel_id: channel-3
    port_id: wasm.wormhole1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrq0kdhcj
  ordering: ORDER_UNORDERED
  port_id: wasm.sei1nna9mzp274djrgzhzkac2gvm3j27l402s4xzr08chq57pjsupqnqaj0d5s
  state: STATE_OPEN
  version: ibc-wormhole-v1
```